### PR TITLE
Enable audio transcode (w/o resampling)

### DIFF
--- a/lib/src/main/java/net/ypresto/androidtranscoder/compat/MediaCodecBufferCompatWrapper.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/compat/MediaCodecBufferCompatWrapper.java
@@ -1,0 +1,42 @@
+package net.ypresto.androidtranscoder.compat;
+
+import android.media.MediaCodec;
+import android.os.Build;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A Wrapper to MediaCodec that facilitates the use of API-dependent get{Input/Output}Buffer methods,
+ * in order to prevent: http://stackoverflow.com/q/30646885
+ */
+public class MediaCodecBufferCompatWrapper {
+
+    final MediaCodec mMediaCodec;
+    final ByteBuffer[] mInputBuffers;
+    final ByteBuffer[] mOutputBuffers;
+
+    public MediaCodecBufferCompatWrapper(MediaCodec mediaCodec) {
+        mMediaCodec = mediaCodec;
+
+        if (Build.VERSION.SDK_INT < 21) {
+            mInputBuffers = mediaCodec.getInputBuffers();
+            mOutputBuffers = mediaCodec.getOutputBuffers();
+        } else {
+            mInputBuffers = mOutputBuffers = null;
+        }
+    }
+
+    public ByteBuffer getInputBuffer(final int index) {
+        if (Build.VERSION.SDK_INT >= 21) {
+            return mMediaCodec.getInputBuffer(index);
+        }
+        return mInputBuffers[index];
+    }
+
+    public ByteBuffer getOutputBuffer(final int index) {
+        if (Build.VERSION.SDK_INT >= 21) {
+            return mMediaCodec.getOutputBuffer(index);
+        }
+        return mOutputBuffers[index];
+    }
+}

--- a/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioChannel.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioChannel.java
@@ -1,0 +1,232 @@
+package net.ypresto.androidtranscoder.engine;
+
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+
+import net.ypresto.androidtranscoder.compat.MediaCodecBufferCompatWrapper;
+import net.ypresto.androidtranscoder.utils.AudioConversionUtils;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.ShortBuffer;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/**
+ * Channel of raw audio from decoder to encoder.
+ * Performs the necessary conversion between different input & output audio formats.
+ *
+ * We currently support upmixing from mono to stereo & downmixing from stereo to mono.
+ * Sample rate conversion is not supported yet.
+ */
+class AudioChannel {
+
+    private static class AudioBuffer {
+        int bufferIndex;
+        long presentationTimeUs;
+        ShortBuffer data;
+    }
+
+    public static final int BUFFER_INDEX_END_OF_STREAM = -1;
+
+    private static final int BYTES_PER_SHORT = 2;
+    private static final long MICROSECS_PER_SEC = 1000000;
+
+    private final Queue<AudioBuffer> mEmptyBuffers = new ArrayDeque<>();
+    private final Queue<AudioBuffer> mFilledBuffers = new ArrayDeque<>();
+
+    private final MediaCodec mDecoder;
+    private final MediaCodec mEncoder;
+    private final MediaFormat mEncodeFormat;
+
+    private int mInputSampleRate;
+    private int mInputChannelCount;
+    private int mOutputChannelCount;
+
+    private AudioConversionUtils.Remixer mRemixer;
+
+    private final MediaCodecBufferCompatWrapper mDecoderBuffers;
+    private final MediaCodecBufferCompatWrapper mEncoderBuffers;
+
+    private final AudioBuffer mOverflowBuffer = new AudioBuffer();
+
+    private MediaFormat mActualDecodedFormat;
+
+
+    public AudioChannel(final MediaCodec decoder,
+                        final MediaCodec encoder, final MediaFormat encodeFormat) {
+        mDecoder = decoder;
+        mEncoder = encoder;
+        mEncodeFormat = encodeFormat;
+
+        mDecoderBuffers = new MediaCodecBufferCompatWrapper(mDecoder);
+        mEncoderBuffers = new MediaCodecBufferCompatWrapper(mEncoder);
+    }
+
+    public void setActualDecodedFormat(final MediaFormat decodedFormat) {
+        mActualDecodedFormat = decodedFormat;
+
+        mInputSampleRate = mActualDecodedFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE);
+        if (mInputSampleRate != mEncodeFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)) {
+            throw new UnsupportedOperationException("Audio sample rate conversion not supported yet.");
+        }
+
+        mInputChannelCount = mActualDecodedFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT);
+        mOutputChannelCount = mEncodeFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT);
+
+        if (mInputChannelCount != 1 && mInputChannelCount != 2) {
+            throw new UnsupportedOperationException("Input channel count (" + mInputChannelCount + ") not supported.");
+        }
+
+        if (mOutputChannelCount != 1 && mOutputChannelCount != 2) {
+            throw new UnsupportedOperationException("Output channel count (" + mOutputChannelCount + ") not supported.");
+        }
+
+        if (mInputChannelCount > mOutputChannelCount) {
+            mRemixer = AudioConversionUtils.REMIXER_DOWNMIX;
+        } else if (mInputChannelCount < mOutputChannelCount) {
+            mRemixer = AudioConversionUtils.REMIXER_UPMIX;
+        } else {
+            mRemixer = AudioConversionUtils.REMIXER_PASSTHROUGH;
+        }
+
+        mOverflowBuffer.presentationTimeUs = 0;
+    }
+
+    public void drainDecoderBufferAndQueue(final int bufferIndex, final long presentationTimeUs) {
+        if (mActualDecodedFormat == null) {
+            throw new RuntimeException("Buffer received before format!");
+        }
+
+        final ByteBuffer data =
+                bufferIndex == BUFFER_INDEX_END_OF_STREAM ?
+                        null : mDecoderBuffers.getOutputBuffer(bufferIndex);
+
+        AudioBuffer buffer = mEmptyBuffers.poll();
+        if (buffer == null) {
+            buffer = new AudioBuffer();
+        }
+
+        buffer.bufferIndex = bufferIndex;
+        buffer.presentationTimeUs = presentationTimeUs;
+        buffer.data = data == null ? null : data.asShortBuffer();
+
+        if (mOverflowBuffer.data == null) {
+            mOverflowBuffer.data = ByteBuffer
+                    .allocateDirect(data.capacity())
+                    .order(ByteOrder.nativeOrder())
+                    .asShortBuffer();
+            mOverflowBuffer.data.clear().flip();
+        }
+
+        mFilledBuffers.add(buffer);
+    }
+
+    public boolean feedEncoder(long timeoutUs) {
+        final boolean hasOverflow = mOverflowBuffer.data != null && mOverflowBuffer.data.hasRemaining();
+        if (mFilledBuffers.isEmpty() && !hasOverflow) {
+            // No audio data - Bail out
+            return false;
+        }
+
+        final int encoderInBuffIndex = mEncoder.dequeueInputBuffer(timeoutUs);
+        if (encoderInBuffIndex < 0) {
+            // Encoder is full - Bail out
+            return false;
+        }
+
+        // Drain overflow first
+        final ShortBuffer outBuffer = mEncoderBuffers.getInputBuffer(encoderInBuffIndex).asShortBuffer();
+        if (hasOverflow) {
+            final long presentationTimeUs = drainOverflow(outBuffer);
+            mEncoder.queueInputBuffer(encoderInBuffIndex,
+                    0, outBuffer.position() * BYTES_PER_SHORT,
+                    presentationTimeUs, 0);
+            return true;
+        }
+
+        final AudioBuffer inBuffer = mFilledBuffers.poll();
+        if (inBuffer.bufferIndex == BUFFER_INDEX_END_OF_STREAM) {
+            mEncoder.queueInputBuffer(encoderInBuffIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+            return false;
+        }
+
+        final long presentationTimeUs = remixAndMaybeFillOverflow(inBuffer, outBuffer);
+        mEncoder.queueInputBuffer(encoderInBuffIndex,
+                0, outBuffer.position() * BYTES_PER_SHORT,
+                presentationTimeUs, 0);
+        if (inBuffer != null) {
+            mDecoder.releaseOutputBuffer(inBuffer.bufferIndex, false);
+            mEmptyBuffers.add(inBuffer);
+        }
+
+        return true;
+    }
+
+    private static long sampleCountToDurationUs(final int sampleCount,
+                                                final int sampleRate,
+                                                final int channelCount) {
+        return (sampleCount / (sampleRate * MICROSECS_PER_SEC)) / channelCount;
+    }
+
+    private long drainOverflow(final ShortBuffer outBuff) {
+        final ShortBuffer overflowBuff = mOverflowBuffer.data;
+        final int overflowLimit = overflowBuff.limit();
+        final int overflowSize = overflowBuff.remaining();
+
+        final long beginPresentationTimeUs = mOverflowBuffer.presentationTimeUs +
+                sampleCountToDurationUs(overflowBuff.position(), mInputSampleRate, mOutputChannelCount);
+
+        outBuff.clear();
+        // Limit overflowBuff to outBuff's capacity
+        overflowBuff.limit(outBuff.capacity());
+        // Load overflowBuff onto outBuff
+        outBuff.put(overflowBuff);
+
+        if (overflowSize >= outBuff.capacity()) {
+            // Overflow fully consumed - Reset
+            overflowBuff.clear().limit(0);
+        } else {
+            // Only partially consumed - Keep position & restore previous limit
+            overflowBuff.limit(overflowLimit);
+        }
+
+        return beginPresentationTimeUs;
+    }
+
+    private long remixAndMaybeFillOverflow(final AudioBuffer input,
+                                           final ShortBuffer outBuff) {
+        final ShortBuffer inBuff = input.data;
+        final ShortBuffer overflowBuff = mOverflowBuffer.data;
+
+        outBuff.clear();
+
+        // Reset position to 0, and set limit to capacity (Since MediaCodec doesn't do that for us)
+        inBuff.clear();
+
+        if (inBuff.remaining() > outBuff.remaining()) {
+            // Overflow
+            // Limit inBuff to outBuff's capacity
+            inBuff.limit(outBuff.capacity());
+            mRemixer.remix(inBuff, outBuff);
+
+            // Reset limit to its own capacity & Keep position
+            inBuff.limit(inBuff.capacity());
+
+            // Remix the rest onto overflowBuffer
+            // NOTE: We should only reach this point when overflow buffer is empty
+            final long consumedDurationUs =
+                    sampleCountToDurationUs(inBuff.position(), mInputSampleRate, mInputChannelCount);
+            mRemixer.remix(inBuff, overflowBuff);
+
+            // Seal off overflowBuff & mark limit
+            overflowBuff.flip();
+            mOverflowBuffer.presentationTimeUs = input.presentationTimeUs + consumedDurationUs;
+        } else {
+            // No overflow
+            mRemixer.remix(inBuff, outBuff);
+        }
+
+        return input.presentationTimeUs;
+    }
+}

--- a/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioTrackTranscoder.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioTrackTranscoder.java
@@ -1,0 +1,209 @@
+package net.ypresto.androidtranscoder.engine;
+
+import android.media.MediaCodec;
+import android.media.MediaExtractor;
+import android.media.MediaFormat;
+
+import net.ypresto.androidtranscoder.compat.MediaCodecBufferCompatWrapper;
+
+import java.io.IOException;
+
+public class AudioTrackTranscoder implements TrackTranscoder {
+
+    private static final QueuedMuxer.SampleType SAMPLE_TYPE = QueuedMuxer.SampleType.AUDIO;
+
+    private static final int DRAIN_STATE_NONE = 0;
+    private static final int DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY = 1;
+    private static final int DRAIN_STATE_CONSUMED = 2;
+
+    private final MediaExtractor mExtractor;
+    private final QueuedMuxer mMuxer;
+    private long mWrittenPresentationTimeUs;
+
+    private final int mTrackIndex;
+    private final MediaFormat mInputFormat;
+    private final MediaFormat mOutputFormat;
+
+    private final MediaCodec.BufferInfo mBufferInfo = new MediaCodec.BufferInfo();
+    private MediaCodec mDecoder;
+    private MediaCodec mEncoder;
+    private MediaFormat mActualOutputFormat;
+
+    private MediaCodecBufferCompatWrapper mDecoderBuffers;
+    private MediaCodecBufferCompatWrapper mEncoderBuffers;
+
+    private boolean mIsExtractorEOS;
+    private boolean mIsDecoderEOS;
+    private boolean mIsEncoderEOS;
+    private boolean mDecoderStarted;
+    private boolean mEncoderStarted;
+
+    private AudioChannel mAudioChannel;
+
+    public AudioTrackTranscoder(MediaExtractor extractor, int trackIndex,
+                                MediaFormat outputFormat, QueuedMuxer muxer) {
+        mExtractor = extractor;
+        mTrackIndex = trackIndex;
+        mOutputFormat = outputFormat;
+        mMuxer = muxer;
+
+        mInputFormat = mExtractor.getTrackFormat(mTrackIndex);
+    }
+
+    @Override
+    public void setup() {
+        mExtractor.selectTrack(mTrackIndex);
+        try {
+            mEncoder = MediaCodec.createEncoderByType(mOutputFormat.getString(MediaFormat.KEY_MIME));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        mEncoder.configure(mOutputFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
+        mEncoder.start();
+        mEncoderStarted = true;
+        mEncoderBuffers = new MediaCodecBufferCompatWrapper(mEncoder);
+
+        final MediaFormat inputFormat = mExtractor.getTrackFormat(mTrackIndex);
+        try {
+            mDecoder = MediaCodec.createDecoderByType(inputFormat.getString(MediaFormat.KEY_MIME));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        mDecoder.configure(inputFormat, null, null, 0);
+        mDecoder.start();
+        mDecoderStarted = true;
+        mDecoderBuffers = new MediaCodecBufferCompatWrapper(mDecoder);
+
+        mAudioChannel = new AudioChannel(mDecoder, mEncoder, mOutputFormat);
+    }
+
+    @Override
+    public MediaFormat getDeterminedFormat() {
+        return mInputFormat;
+    }
+
+    @Override
+    public boolean stepPipeline() {
+        boolean busy = false;
+
+        int status;
+        while (drainEncoder(0) != DRAIN_STATE_NONE) busy = true;
+        do {
+            status = drainDecoder(0);
+            if (status != DRAIN_STATE_NONE) busy = true;
+            // NOTE: not repeating to keep from deadlock when encoder is full.
+        } while (status == DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY);
+
+        while (mAudioChannel.feedEncoder(0)) busy = true;
+        while (drainExtractor(0) != DRAIN_STATE_NONE) busy = true;
+
+        return busy;
+    }
+
+    private int drainExtractor(long timeoutUs) {
+        if (mIsExtractorEOS) return DRAIN_STATE_NONE;
+        int trackIndex = mExtractor.getSampleTrackIndex();
+        if (trackIndex >= 0 && trackIndex != mTrackIndex) {
+            return DRAIN_STATE_NONE;
+        }
+
+        final int result = mDecoder.dequeueInputBuffer(timeoutUs);
+        if (result < 0) return DRAIN_STATE_NONE;
+        if (trackIndex < 0) {
+            mIsExtractorEOS = true;
+            mDecoder.queueInputBuffer(result, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+            return DRAIN_STATE_NONE;
+        }
+
+        final int sampleSize = mExtractor.readSampleData(mDecoderBuffers.getInputBuffer(result), 0);
+        final boolean isKeyFrame = (mExtractor.getSampleFlags() & MediaExtractor.SAMPLE_FLAG_SYNC) != 0;
+        mDecoder.queueInputBuffer(result, 0, sampleSize, mExtractor.getSampleTime(), isKeyFrame ? MediaCodec.BUFFER_FLAG_SYNC_FRAME : 0);
+        mExtractor.advance();
+        return DRAIN_STATE_CONSUMED;
+    }
+
+    private int drainDecoder(long timeoutUs) {
+        if (mIsDecoderEOS) return DRAIN_STATE_NONE;
+
+        int result = mDecoder.dequeueOutputBuffer(mBufferInfo, timeoutUs);
+        switch (result) {
+            case MediaCodec.INFO_TRY_AGAIN_LATER:
+                return DRAIN_STATE_NONE;
+            case MediaCodec.INFO_OUTPUT_FORMAT_CHANGED:
+                mAudioChannel.setActualDecodedFormat(mDecoder.getOutputFormat());
+            case MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED:
+                return DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY;
+        }
+
+        if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+            mIsDecoderEOS = true;
+            mAudioChannel.drainDecoderBufferAndQueue(AudioChannel.BUFFER_INDEX_END_OF_STREAM, 0);
+        } else if (mBufferInfo.size > 0) {
+            mAudioChannel.drainDecoderBufferAndQueue(result, mBufferInfo.presentationTimeUs);
+        }
+
+        return DRAIN_STATE_CONSUMED;
+    }
+
+    private int drainEncoder(long timeoutUs) {
+        if (mIsEncoderEOS) return DRAIN_STATE_NONE;
+
+        int result = mEncoder.dequeueOutputBuffer(mBufferInfo, timeoutUs);
+        switch (result) {
+            case MediaCodec.INFO_TRY_AGAIN_LATER:
+                return DRAIN_STATE_NONE;
+            case MediaCodec.INFO_OUTPUT_FORMAT_CHANGED:
+                if (mActualOutputFormat != null) {
+                    throw new RuntimeException("Audio output format changed twice.");
+                }
+                mActualOutputFormat = mEncoder.getOutputFormat();
+                mMuxer.setOutputFormat(SAMPLE_TYPE, mActualOutputFormat);
+                return DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY;
+            case MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED:
+                mEncoderBuffers = new MediaCodecBufferCompatWrapper(mEncoder);
+                return DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY;
+        }
+
+        if (mActualOutputFormat == null) {
+            throw new RuntimeException("Could not determine actual output format.");
+        }
+
+        if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+            mIsEncoderEOS = true;
+            mBufferInfo.set(0, 0, 0, mBufferInfo.flags);
+        }
+        if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+            // SPS or PPS, which should be passed by MediaFormat.
+            mEncoder.releaseOutputBuffer(result, false);
+            return DRAIN_STATE_SHOULD_RETRY_IMMEDIATELY;
+        }
+        mMuxer.writeSampleData(SAMPLE_TYPE, mEncoderBuffers.getOutputBuffer(result), mBufferInfo);
+        mWrittenPresentationTimeUs = mBufferInfo.presentationTimeUs;
+        mEncoder.releaseOutputBuffer(result, false);
+        return DRAIN_STATE_CONSUMED;
+    }
+
+    @Override
+    public long getWrittenPresentationTimeUs() {
+        return mWrittenPresentationTimeUs;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return mIsEncoderEOS;
+    }
+
+    @Override
+    public void release() {
+        if (mDecoder != null) {
+            if (mDecoderStarted) mDecoder.stop();
+            mDecoder.release();
+            mDecoder = null;
+        }
+        if (mEncoder != null) {
+            if (mEncoderStarted) mEncoder.stop();
+            mEncoder.release();
+            mEncoder = null;
+        }
+    }
+}

--- a/lib/src/main/java/net/ypresto/androidtranscoder/engine/MediaTranscoderEngine.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/engine/MediaTranscoderEngine.java
@@ -173,7 +173,7 @@ public class MediaTranscoderEngine {
         if (audioOutputFormat == null) {
             mAudioTrackTranscoder = new PassThroughTrackTranscoder(mExtractor, trackResult.mAudioTrackIndex, queuedMuxer, QueuedMuxer.SampleType.AUDIO);
         } else {
-            throw new UnsupportedOperationException("Transcoding audio tracks currently not supported.");
+            mAudioTrackTranscoder = new AudioTrackTranscoder(mExtractor, trackResult.mAudioTrackIndex, audioOutputFormat, queuedMuxer);
         }
         mAudioTrackTranscoder.setup();
         mExtractor.selectTrack(trackResult.mVideoTrackIndex);

--- a/lib/src/main/java/net/ypresto/androidtranscoder/format/Android16By9FormatStrategy.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/format/Android16By9FormatStrategy.java
@@ -23,11 +23,19 @@ class Android16By9FormatStrategy implements MediaFormatStrategy {
     public static final int SCALE_720P = 5;
     private static final String TAG = "Android16By9FormatStrategy";
     private final int mScale;
-    private final int mBitrate;
+    private final int mVideoBitrate;
+    private final int mAudioBitrate;
+    private final int mAudioChannels;
 
-    public Android16By9FormatStrategy(int scale, int bitrate) {
+    public Android16By9FormatStrategy(int scale, int videoBitrate) {
+        this(scale, videoBitrate, 0, 0);
+    }
+
+    public Android16By9FormatStrategy(int scale, int videoBitrate, int audioBitrate, int audioChannels) {
         mScale = scale;
-        mBitrate = bitrate;
+        mVideoBitrate = videoBitrate;
+        mAudioBitrate = audioBitrate;
+        mAudioChannels = audioChannels;
     }
 
     @Override
@@ -57,7 +65,7 @@ class Android16By9FormatStrategy implements MediaFormatStrategy {
         }
         MediaFormat format = MediaFormat.createVideoFormat("video/avc", outWidth, outHeight);
         // From Nexus 4 Camera in 720p
-        format.setInteger(MediaFormat.KEY_BIT_RATE, mBitrate);
+        format.setInteger(MediaFormat.KEY_BIT_RATE, mVideoBitrate);
         format.setInteger(MediaFormat.KEY_FRAME_RATE, 30);
         format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 3);
         format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
@@ -66,6 +74,13 @@ class Android16By9FormatStrategy implements MediaFormatStrategy {
 
     @Override
     public MediaFormat createAudioOutputFormat(MediaFormat inputFormat) {
-        return null;
+        if (mAudioBitrate == 0 || mAudioChannels == 0) return null;
+
+        // Use original sample rate, as resampling is not supported yet.
+        final MediaFormat format = MediaFormat.createAudioFormat(MediaFormatExtraConstants.MIMETYPE_AUDIO_AAC,
+                inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE), mAudioChannels);
+        format.setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC);
+        format.setInteger(MediaFormat.KEY_BIT_RATE, mAudioBitrate);
+        return format;
     }
 }

--- a/lib/src/main/java/net/ypresto/androidtranscoder/format/Android720pFormatStrategy.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/format/Android720pFormatStrategy.java
@@ -24,14 +24,22 @@ class Android720pFormatStrategy implements MediaFormatStrategy {
     private static final int LONGER_LENGTH = 1280;
     private static final int SHORTER_LENGTH = 720;
     private static final int DEFAULT_BITRATE = 8000 * 1000; // From Nexus 4 Camera in 720p
-    private final int mBitRate;
+    private final int mVideoBitRate;
+    private final int mAudioBitrate;
+    private final int mAudioChannels;
 
     public Android720pFormatStrategy() {
-        mBitRate = DEFAULT_BITRATE;
+        this(DEFAULT_BITRATE, 0, 0);
     }
 
-    public Android720pFormatStrategy(int bitRate) {
-        mBitRate = bitRate;
+    public Android720pFormatStrategy(int videoBitrate) {
+        this(videoBitrate, 0, 0);
+    }
+
+    public Android720pFormatStrategy(int videoBitrate, int audioBitrate, int audioChannels) {
+        mVideoBitRate = videoBitrate;
+        mAudioBitrate = audioBitrate;
+        mAudioChannels = audioChannels;
     }
 
     @Override
@@ -59,7 +67,7 @@ class Android720pFormatStrategy implements MediaFormatStrategy {
         }
         MediaFormat format = MediaFormat.createVideoFormat("video/avc", outWidth, outHeight);
         // From Nexus 4 Camera in 720p
-        format.setInteger(MediaFormat.KEY_BIT_RATE, mBitRate);
+        format.setInteger(MediaFormat.KEY_BIT_RATE, mVideoBitRate);
         format.setInteger(MediaFormat.KEY_FRAME_RATE, 30);
         format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 3);
         format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
@@ -68,6 +76,13 @@ class Android720pFormatStrategy implements MediaFormatStrategy {
 
     @Override
     public MediaFormat createAudioOutputFormat(MediaFormat inputFormat) {
-        return null;
+        if (mAudioBitrate == 0 || mAudioChannels == 0) return null;
+
+        // Use original sample rate, as resampling is not supported yet.
+        final MediaFormat format = MediaFormat.createAudioFormat(MediaFormatExtraConstants.MIMETYPE_AUDIO_AAC,
+                inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE), mAudioChannels);
+        format.setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC);
+        format.setInteger(MediaFormat.KEY_BIT_RATE, mAudioBitrate);
+        return format;
     }
 }

--- a/lib/src/main/java/net/ypresto/androidtranscoder/utils/AudioConversionUtils.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/utils/AudioConversionUtils.java
@@ -1,0 +1,69 @@
+package net.ypresto.androidtranscoder.utils;
+
+import java.nio.ShortBuffer;
+
+public class AudioConversionUtils {
+
+    public interface Remixer {
+        void remix(final ShortBuffer inSBuff, final ShortBuffer outSBuff);
+    }
+
+    public static final Remixer REMIXER_DOWNMIX = new Remixer() {
+        private static final int SIGNED_SHORT_LIMIT = 32768;
+        private static final int UNSIGNED_SHORT_MAX = 65535;
+
+        @Override
+        public void remix(final ShortBuffer inSBuff, final ShortBuffer outSBuff) {
+            // Down-mix stereo to mono
+            // Viktor Toth's algorithm -
+            // See: http://www.vttoth.com/CMS/index.php/technical-notes/68
+            //      http://stackoverflow.com/a/25102339
+            final int inRemaining = inSBuff.remaining() / 2;
+            final int outSpace = outSBuff.remaining();
+
+            final int samplesToBeProcessed = Math.min(inRemaining, outSpace);
+            for (int i = 0; i < samplesToBeProcessed; ++i) {
+                // Convert to unsigned
+                final int a = inSBuff.get() + SIGNED_SHORT_LIMIT;
+                final int b = inSBuff.get() + SIGNED_SHORT_LIMIT;
+                int m;
+                // Pick the equation
+                if ((a < SIGNED_SHORT_LIMIT) || (b < SIGNED_SHORT_LIMIT)) {
+                    // Viktor's first equation when both sources are "quiet"
+                    // (i.e. less than middle of the dynamic range)
+                    m = a * b / SIGNED_SHORT_LIMIT;
+                } else {
+                    // Viktor's second equation when one or both sources are loud
+                    m = 2 * (a + b) - (a * b) / SIGNED_SHORT_LIMIT - UNSIGNED_SHORT_MAX;
+                }
+                // Convert output back to signed short
+                if (m == UNSIGNED_SHORT_MAX + 1) m = UNSIGNED_SHORT_MAX;
+                outSBuff.put((short) (m - SIGNED_SHORT_LIMIT));
+            }
+        }
+    };
+
+    public static final Remixer REMIXER_UPMIX = new Remixer() {
+        @Override
+        public void remix(final ShortBuffer inSBuff, final ShortBuffer outSBuff) {
+            // Up-mix mono to stereo
+            final int inRemaining = inSBuff.remaining();
+            final int outSpace = outSBuff.remaining() / 2;
+
+            final int samplesToBeProcessed = Math.min(inRemaining, outSpace);
+            for (int i = 0; i < samplesToBeProcessed; ++i) {
+                final short inSample = inSBuff.get();
+                outSBuff.put(inSample);
+                outSBuff.put(inSample);
+            }
+        }
+    };
+
+    public static final Remixer REMIXER_PASSTHROUGH = new Remixer() {
+        @Override
+        public void remix(final ShortBuffer inSBuff, final ShortBuffer outSBuff) {
+            // Passthrough
+            outSBuff.put(inSBuff);
+        }
+    };
+}


### PR DESCRIPTION
Add support for audio transcoding. (Bitrate, mono to stereo & stereo to mono)
Resampling not supported yet.

* Retrofitted VideoTrackTranscoder to AudioTrackTranscoder.
* Added AudioChannel for audio conversion.
* Added option for specifying audio bitrate & channel count in Android720pFormatStrategy & Android16By9FormatStrategy.