### PR TITLE
Close stream before calling listener events

### DIFF
--- a/lib/src/main/java/net/ypresto/androidtranscoder/MediaTranscoder.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/MediaTranscoder.java
@@ -123,20 +123,20 @@ public class MediaTranscoder {
 
             @Override
             public void onTranscodeCompleted() {
-                listener.onTranscodeCompleted();
                 closeStream();
+                listener.onTranscodeCompleted();
             }
 
             @Override
             public void onTranscodeCanceled() {
-                listener.onTranscodeCanceled();
                 closeStream();
+                listener.onTranscodeCanceled();
             }
 
             @Override
             public void onTranscodeFailed(Exception exception) {
-                listener.onTranscodeFailed(exception);
                 closeStream();
+                listener.onTranscodeFailed(exception);
             }
 
             private void closeStream() {


### PR DESCRIPTION
https://github.com/ergovia-mobile/android-transcoder/pull/1
https://github.com/ergovia-mobile/android-transcoder/commit/615042896833aaab7fa6f0be19d582fca6291eca

> A race condition can occur on a Samsung Galaxy 2 Camera resulting in a timeout if you attempt to upload a recorded video using the cordova-plugin-file-transfer plugin inside the onTransferComplete callback.
> 
> The solution is to close the output file stream before raising the callback function.

Thanks for @ryanwilliams83 ..!

