### PR TITLE
Support geo metadata

### DIFF
--- a/lib/src/androidTest/java/net/ypresto/androidtranscoder/utils/ISO6709LocationParserTest.java
+++ b/lib/src/androidTest/java/net/ypresto/androidtranscoder/utils/ISO6709LocationParserTest.java
@@ -1,0 +1,35 @@
+package net.ypresto.androidtranscoder.utils;
+
+import junit.framework.TestCase;
+
+public class ISO6709LocationParserTest extends TestCase {
+    public void testParse() {
+        ISO6709LocationParser parser = new ISO6709LocationParser();
+        assertEquals(new float[]{35.658632f, 139.745411f}, parser.parse("+35.658632+139.745411/"));
+        assertEquals(new float[]{40.75f, -074.00f}, parser.parse("+40.75-074.00/"));
+        // with Altitude
+        assertEquals(new float[]{-90f, +0f}, parser.parse("-90+000+2800/"));
+        assertEquals(new float[]{27.5916f, 086.5640f}, parser.parse("+27.5916+086.5640+8850/"));
+        // ranged data
+        assertEquals(new float[]{35.331f, 134.224f}, parser.parse("+35.331+134.224/+35.336+134.228/"));
+        assertEquals(new float[]{35.331f, 134.224f}, parser.parse("+35.331+134.224/+35.336+134.228/+35.333+134.229/+35.333+134.227/"));
+    }
+
+    public void testParseFailure() {
+        ISO6709LocationParser parser = new ISO6709LocationParser();
+        assertNull(parser.parse(null));
+        assertNull(parser.parse(""));
+        assertNull(parser.parse("35 deg 65' 86.32\" N, 139 deg 74' 54.11\" E"));
+        assertNull(parser.parse("+35.658632"));
+        assertNull(parser.parse("+35.658632-"));
+        assertNull(parser.parse("40.75-074.00"));
+        assertNull(parser.parse("+40.75-074.00.00"));
+    }
+
+    private static void assertEquals(float[] expected, float[] actual) {
+        assertEquals(expected.length, actual.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertTrue(Float.compare(expected[i], actual[i]) == 0);
+        }
+    }
+}

--- a/lib/src/main/java/net/ypresto/androidtranscoder/engine/MediaTranscoderEngine.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/engine/MediaTranscoderEngine.java
@@ -19,9 +19,12 @@ import android.media.MediaExtractor;
 import android.media.MediaFormat;
 import android.media.MediaMetadataRetriever;
 import android.media.MediaMuxer;
+import android.os.Build;
 import android.util.Log;
 
+import net.ypresto.androidtranscoder.BuildConfig;
 import net.ypresto.androidtranscoder.format.MediaFormatStrategy;
+import net.ypresto.androidtranscoder.utils.ISO6709LocationParser;
 import net.ypresto.androidtranscoder.utils.MediaExtractorUtils;
 
 import java.io.FileDescriptor;
@@ -137,9 +140,17 @@ public class MediaTranscoderEngine {
             // skip
         }
 
-        // TODO: parse ISO 6709
-        // String locationString = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_LOCATION);
-        // mMuxer.setLocation(Integer.getInteger(rotationString, 0));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            String locationString = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_LOCATION);
+            if (locationString != null) {
+                float[] location = new ISO6709LocationParser().parse(locationString);
+                if (location != null) {
+                    mMuxer.setLocation(location[0], location[1]);
+                } else {
+                    Log.d(TAG, "Failed to parse the location metadata: " + locationString);
+                }
+            }
+        }
 
         try {
             mDurationUs = Long.parseLong(mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)) * 1000;

--- a/lib/src/main/java/net/ypresto/androidtranscoder/utils/ISO6709LocationParser.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/utils/ISO6709LocationParser.java
@@ -1,0 +1,37 @@
+package net.ypresto.androidtranscoder.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ISO6709LocationParser {
+    private final Pattern pattern;
+
+    public ISO6709LocationParser() {
+        this.pattern = Pattern.compile("([+\\-][0-9.]+)([+\\-][0-9.]+)");
+    }
+
+    /**
+     * This method parses the given string representing a geographic point location by coordinates in ISO 6709 format
+     * and returns the latitude and the longitude in float. If <code>location</code> is not in ISO 6709 format,
+     * this method returns <code>null</code>
+     *
+     * @param location a String representing a geographic point location by coordinates in ISO 6709 format
+     * @return <code>null</code> if the given string is not as expected, an array of floats with size 2,
+     * where the first element represents latitude and the second represents longitude, otherwise.
+     */
+    public float[] parse(String location) {
+        if (location == null) return null;
+        Matcher m = pattern.matcher(location);
+        if (m.find() && m.groupCount() == 2) {
+            String latstr = m.group(1);
+            String lonstr = m.group(2);
+            try {
+                float lat = Float.parseFloat(latstr);
+                float lon = Float.parseFloat(lonstr);
+                return new float[]{lat, lon};
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
# Goal
This PR adds geo metadata support.

# Description
With this PR, MediaTranscoderEngine extracts geographical data in ISO 6709 format from the input file and passes the data to the multiplexer so that the output file does not lose the geolocation information.

# How to verify
Run the example app and transcode a movie file with geolocation data.  Verify the output data has the geolocation data like below.

```diff
@@ -28,10 +28,11 @@
 Selection Duration              : 0 s
 Current Time                    : 0 s
 Next Track ID                   : 3
+GPS Coordinates                 : 35 deg 65' 86.32" N, 139 deg 74' 54.11" E
 Com Android Version             : 8.1.0
 Track Header Version            : 0
@@ -63,6 +64,9 @@
 Audio Bits Per Sample           : 16
 Audio Sample Rate               : 48000
 Avg Bitrate                     : 8.16 Mbps
+GPS Latitude                    : 35 deg 65' 86.32" N
+GPS Longitude                   : 139 deg 74' 54.11" E
+GPS Position                    : 35 deg 65' 86.32" N, 139 deg 74' 54.11" E
 Image Size                      : 1280x720
 Megapixels                      : 0.922
 Rotation                        : 0
```