### PR TITLE
Fix audio format validation

### DIFF
--- a/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioTrackTranscoder.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/engine/AudioTrackTranscoder.java
@@ -79,7 +79,7 @@ public class AudioTrackTranscoder implements TrackTranscoder {
 
     @Override
     public MediaFormat getDeterminedFormat() {
-        return mInputFormat;
+        return mActualOutputFormat;
     }
 
     @Override


### PR DESCRIPTION
Confirmed  fix for issue:
https://github.com/ypresto/android-transcoder/issues/69

Pre fix:
using Android720pFormatStrategy and getting a runtime exception on short video created in an Android 8.0.0 Nexus 5X emulator.

Post Fix:
using Android720pFormatStrategy and getting a successful transcoding on short video created in an Android 8.0.0 Nexus 5X emulator.

Also, bumped version for bug fix to 3.0.1