### PR TITLE
support drop frames transcode

### DIFF
--- a/lib/src/main/java/net/ypresto/androidtranscoder/engine/VideoTrackTranscoder.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/engine/VideoTrackTranscoder.java
@@ -200,9 +200,7 @@ public class VideoTrackTranscoder implements TrackTranscoder {
         // NOTE: output frame rate is ignored if source video frame rate is too large(such as 60fps)
         // So drop some frame
         if (checkDropFrame()) {
-            if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_KEY_FRAME) == 0) {
-                return DRAIN_STATE_CONSUMED;
-            }
+            return DRAIN_STATE_CONSUMED;
         }
         if (doRender) {
             mDecoderOutputSurfaceWrapper.awaitNewImage();


### PR DESCRIPTION
The source video frame rate is larger the dest video( such as 60fps transcode to 30fps). But mediacodec ignore frame rate, according to https://stackoverflow.com/questions/22336604/mediacodec-key-frame-rate-seems-to-be-ignored.
I code drop frames logic according to https://stackoverflow.com/questions/4223766/dropping-video-frames.